### PR TITLE
[fix] getWorld null on load resetting REJECT links

### DIFF
--- a/EpicHoppers-Plugin/src/main/resources/plugin.yml
+++ b/EpicHoppers-Plugin/src/main/resources/plugin.yml
@@ -24,7 +24,7 @@ softdepend:
   - Vault
   - WildStacker
   - WorldGuard
-
+load: POSTWORLD
 author: Craftaro
 website: ${project.parent.url}
 


### PR DESCRIPTION
Adjust load logic in plugin yml t load after the world fixing null world wiping rejected links on startup